### PR TITLE
Update MDF cut and mark settings

### DIFF
--- a/laserprofiles/Leeds_32_LAOS/MDF/3.0mm/Cut.xml
+++ b/laserprofiles/Leeds_32_LAOS/MDF/3.0mm/Cut.xml
@@ -1,7 +1,7 @@
 <linked-list>
   <LaosCutterProperty>
     <power>100.0</power>
-    <speed>20.0</speed>
+    <speed>14.0</speed>
     <focus>0.0</focus>
     <frequency>500</frequency>
     <hidePurge>true</hidePurge>

--- a/laserprofiles/Leeds_32_LAOS/MDF/3.0mm/Mark_32__40_Deep_41_.xml
+++ b/laserprofiles/Leeds_32_LAOS/MDF/3.0mm/Mark_32__40_Deep_41_.xml
@@ -1,0 +1,14 @@
+<linked-list>
+  <LaosCutterProperty>
+    <power>45.0</power>
+    <speed>100.0</speed>
+    <focus>0.0</focus>
+    <frequency>500</frequency>
+    <hidePurge>true</hidePurge>
+    <hideVentilation>true</hideVentilation>
+    <hideFocus>true</hideFocus>
+    <hideFrequency>true</hideFrequency>
+    <ventilation>true</ventilation>
+    <purge>true</purge>
+  </LaosCutterProperty>
+</linked-list>

--- a/laserprofiles/Leeds_32_LAOS/MDF/3.0mm/Mark_32__40_Shallow_41_.xml
+++ b/laserprofiles/Leeds_32_LAOS/MDF/3.0mm/Mark_32__40_Shallow_41_.xml
@@ -1,0 +1,14 @@
+<linked-list>
+  <LaosCutterProperty>
+    <power>40.0</power>
+    <speed>65.0</speed>
+    <focus>0.0</focus>
+    <frequency>500</frequency>
+    <hidePurge>true</hidePurge>
+    <hideVentilation>true</hideVentilation>
+    <hideFocus>true</hideFocus>
+    <hideFrequency>true</hideFrequency>
+    <ventilation>true</ventilation>
+    <purge>true</purge>
+  </LaosCutterProperty>
+</linked-list>


### PR DESCRIPTION
MDF cut speed was too high at 20; reducing to 14 seems to make reliable cuts
